### PR TITLE
Add multi-collection support to MCP server tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,16 +762,19 @@ To save the query results to JSON files, run this:
 
 **Archive Agent** exposes these tools via MCP:
 
-| MCP tool            | Equivalent CLI command(s) | Argument(s) | Implementation | Description                                     |
-|---------------------|---------------------------|-------------|----------------|-------------------------------------------------|
-| `get_patterns`      | `patterns`                | None        | Synchronous    | Get the list of included / excluded patterns.   |
-| `get_files_tracked` | `track` and then `list`   | None        | Synchronous    | Get the list of tracked files.                  |
-| `get_files_changed` | `track` and then `diff`   | None        | Synchronous    | Get the list of changed files.                  |
-| `get_chunk_headers` | None                      | `file_path` | Asynchronous   | Get list of chunk headers for a file.           |
-| `get_search_result` | `search`                  | `question`  | Asynchronous   | Get the list of files relevant to the question. |
-| `get_answer_rag`    | `query`                   | `question`  | Asynchronous   | Get answer to question using RAG.               |
+| MCP tool            | Equivalent CLI command(s) | Argument(s)                        | Implementation | Description                                     |
+|---------------------|---------------------------|------------------------------------|----------------|-------------------------------------------------|
+| `get_patterns`      | `patterns`                | None                               | Synchronous    | Get the list of included / excluded patterns.   |
+| `get_files_tracked` | `track` and then `list`   | None                               | Synchronous    | Get the list of tracked files.                  |
+| `get_files_changed` | `track` and then `diff`   | None                               | Synchronous    | Get the list of changed files.                  |
+| `get_collections`   | None                      | None                               | Synchronous    | Get the list of available Qdrant collections.   |
+| `get_chunk_headers` | None                      | `file_path` [, `collection`]       | Asynchronous   | Get list of chunk headers for a file.           |
+| `get_search_result` | `search`                  | `question` [, `collection`]        | Asynchronous   | Get the list of files relevant to the question. |
+| `get_answer_rag`    | `query`                   | `question` [, `collection`]        | Asynchronous   | Get answer to question using RAG.               |
 
 📌 **Note:** These commands are **read-only**, preventing the AI from changing your Qdrant database.
+
+💡 **Good to know:** The optional `collection` parameter lets you query any Qdrant collection by name. If omitted, the active profile's collection is used. Use `#get_collections` to discover available collections.
 
 💡 **Good to know:** Just type `#get_answer_rag` (e.g.) in your IDE or AI extension to call the tool directly.
 


### PR DESCRIPTION
## Summary
This PR adds support for querying multiple Qdrant collections in the MCP server, allowing users to specify which collection to search instead of being limited to the active profile's default collection.

## Key Changes
- **Added `_get_qdrant()` helper function** in McpServer.py to handle collection resolution with validation, supporting both default and custom collection names
- **Extended MCP tool signatures** to accept optional `collection` parameter:
  - `get_search_result(question, collection=None)`
  - `get_chunk_headers(file_path, collection=None)`
  - `get_answer_rag(question, collection=None)`
- **Added new `get_collections()` MCP tool** to list all available Qdrant collections and identify the default one
- **Implemented collection management methods** in QdrantManager:
  - `with_collection(collection)`: Creates a shallow copy pointing to a different collection while sharing the client connection
  - `verify_collection_exists()`: Validates that a collection exists before use
  - `get_collections()`: Retrieves all available collections from Qdrant

## Implementation Details
- The `_get_qdrant()` helper validates custom collections exist and raises `ValueError` if not found, providing clear error messages
- Collection switching uses shallow copying to avoid duplicating the expensive Qdrant client connection
- All collection-aware tools default to the active profile's collection when no override is specified, maintaining backward compatibility
- Retry logic is properly applied to new Qdrant operations for robustness

https://claude.ai/code/session_01NBCzbp8teEoyCoG2Rn16JW